### PR TITLE
Encode TRA for M2Crypto Memory Buffer in py3

### DIFF
--- a/wsaa.py
+++ b/wsaa.py
@@ -91,9 +91,9 @@ def sign_tra(tra, cert=CERT, privatekey=PRIVATEKEY, passphrase=""):
 
     if BIO:
         # Firmar el texto (tra) usando m2crypto (openssl bindings para python)
-        buf = BIO.MemoryBuffer(tra)             # Crear un buffer desde el texto
-        #Rand.load_file('randpool.dat', -1)     # Alimentar el PRNG
-        s = SMIME.SMIME()                       # Instanciar un SMIME
+        buf = BIO.MemoryBuffer(tra.encode('utf-8'))             # Crear un buffer desde el texto
+        #Rand.load_file('randpool.dat', -1)                     # Alimentar el PRNG
+        s = SMIME.SMIME()                                       # Instanciar un SMIME
         # soporte de contraseña de encriptación (clave privada, opcional)
         callback = lambda *args, **kwarg: passphrase
         # Cargar clave privada y certificado


### PR DESCRIPTION
In Python 2, the str type was used for two different kinds of values: text and bytes; whereas in Python 3, these are separate and incompatible types. In py3 envs we need to pass the TRA encoded, otherwise an exception is raised.